### PR TITLE
Add wxpython 4.2.x compatibility

### DIFF
--- a/GoSync/DriveUsageBox.py
+++ b/GoSync/DriveUsageBox.py
@@ -72,7 +72,7 @@ class DriveUsageBox(wx.Panel):
         mainSizer = wx.BoxSizer(wx.VERTICAL)
         mainSizer.Add(self.t1, 0, wx.ALL|wx.EXPAND, 5)
         #mainSizer.Add(self.basePanel, 0, wx.ALL|wx.FIXED_MINSIZE, 5)
-        mainSizer.Add(self.basePanel, 0, wx.ALL|wx.EXPAND|wx.ALIGN_CENTER, 10)
+        mainSizer.Add(self.basePanel, 0, wx.ALL|wx.EXPAND, 10)
 
         legendAudio = wx.Panel(self, size=legendSize, style=legendStyle)
         legendAudio.SetBackgroundColour(self.audioPanelColor)
@@ -125,7 +125,7 @@ class DriveUsageBox(wx.Panel):
         legendSizer.Add(legendFree, 0, wx.ALL|wx.EXPAND, 5)
         legendSizer.Add(legendFreeText, 0, wx.ALL|wx.EXPAND, 5)
 
-        mainSizer.Add(legendSizer, 1, wx.ALL|wx.ALIGN_CENTER|wx.EXPAND, 10)
+        mainSizer.Add(legendSizer, 1, wx.ALL|wx.EXPAND, 10)
         self.SetSizerAndFit(mainSizer)
 
     def FileSizeHumanize(self, size):

--- a/GoSync/GoSyncSelectionPage.py
+++ b/GoSync/GoSyncSelectionPage.py
@@ -34,7 +34,7 @@ class SelectionPage(wx.Panel):
     def __init__(self, parent, sync_model):
         wx.Panel.__init__(self, parent, style=wx.RAISED_BORDER)
 
-        headerFont = wx.Font(11.5, wx.SWISS, wx.NORMAL, wx.NORMAL)
+        headerFont = wx.Font(12, wx.SWISS, wx.NORMAL, wx.NORMAL)
 
         self.sync_model = sync_model
         self.dstc = GoSyncDriveTree(self, pos=(0,0))

--- a/GoSync/GoSyncSettingsPage.py
+++ b/GoSync/GoSyncSettingsPage.py
@@ -34,7 +34,7 @@ class SettingsPage(wx.Panel):
     def __init__(self, parent, sync_model):
         wx.Panel.__init__(self, parent)
 
-        headerFont = wx.Font(11.5, wx.SWISS, wx.NORMAL, wx.NORMAL)
+        headerFont = wx.Font(12, wx.SWISS, wx.NORMAL, wx.NORMAL)
 
         self.sync_model = sync_model
         self.dstc = GoSyncDriveTree(self, pos=(0,0))


### PR DESCRIPTION
Running the app, both from `pip` and from sources, I get the below error. 
The cause is that the wxpython 4.2.1 API, which is what's available and installed on the latest Ubuntu (23.10), doesn't allow font sizes of type 'float'. 
The fix is to simply use an integer font size everywhere in the code. 

```

$ GoSync
Traceback (most recent call last):
  File "/usr/local/bin/GoSync", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/GoSync/GoSync.py", line 38, in main
    controller = GoSyncController()
                 ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/GoSync/GoSyncController.py", line 171, in __init__
    selectionPage = SelectionPage(nb, self.sync_model)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/GoSync/GoSyncSelectionPage.py", line 37, in __init__
    headerFont = wx.Font(11.5, wx.SWISS, wx.NORMAL, wx.NORMAL)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Font(): arguments did not match any overloaded call:
  overload 1: too many arguments
  overload 2: argument 1 has unexpected type 'float'
  overload 3: argument 1 has unexpected type 'float'
  overload 4: argument 1 has unexpected type 'float'
  overload 5: argument 1 has unexpected type 'float'
  overload 6: argument 1 has unexpected type 'float'
  overload 7: argument 1 has unexpected type 'float'

```